### PR TITLE
Moved to Network.Nanomsg and use Tasty and 0MQ4

### DIFF
--- a/benchmarks/SendMessages.hs
+++ b/benchmarks/SendMessages.hs
@@ -1,6 +1,6 @@
 module Main where
 
-import Nanomsg
+import Network.Nanomsg
 import Criterion.Main
 import qualified Data.ByteString.Char8 as C
 import Control.Monad (replicateM_)

--- a/benchmarks/Zmq.hs
+++ b/benchmarks/Zmq.hs
@@ -1,7 +1,7 @@
 module Main where
 
-import qualified Nanomsg as N
-import qualified System.ZMQ3.Monadic as Z
+import qualified Network.Nanomsg as N
+import qualified System.ZMQ4.Monadic as Z
 import Criterion.Main
 import qualified Data.ByteString.Char8 as C
 import Control.Monad (replicateM_)
@@ -57,16 +57,16 @@ zThr size count bindString connString = Z.runZMQ $ do
 main :: IO ()
 main = defaultMain
     [ bench "nanomsg-haskell: 40 bytes x 2k messages, lat, tcp"     $ nfIO $ nLat    40 1000 "tcp://*:5566" "tcp://localhost:5566"
-    , bench "zeromq3-haskell: 40 bytes x 2k messages, lat, tcp"     $ nfIO $ zLat    40 1000 "tcp://*:5566" "tcp://localhost:5566"
+    , bench "zeromq4-haskell: 40 bytes x 2k messages, lat, tcp"     $ nfIO $ zLat    40 1000 "tcp://*:5566" "tcp://localhost:5566"
     , bench "nanomsg-haskell: 20k bytes x 40 messages, lat, tcp"    $ nfIO $ nLat 20000   20 "tcp://*:5566" "tcp://localhost:5566"
-    , bench "zeromq3-haskell: 20k bytes x 40 messages, lat, tcp"    $ nfIO $ zLat 20000   20 "tcp://*:5566" "tcp://localhost:5566"
+    , bench "zeromq4-haskell: 20k bytes x 40 messages, lat, tcp"    $ nfIO $ zLat 20000   20 "tcp://*:5566" "tcp://localhost:5566"
     , bench "nanomsg-haskell: 40 bytes x 2k messages, lat, inproc"  $ nfIO $ nLat    40 1000 "inproc://bench" "inproc://bench"
-    , bench "zeromq3-haskell: 40 bytes x 2k messages, lat, inproc"  $ nfIO $ zLat    40 1000 "inproc://bench" "inproc://bench"
+    , bench "zeromq4-haskell: 40 bytes x 2k messages, lat, inproc"  $ nfIO $ zLat    40 1000 "inproc://bench" "inproc://bench"
     , bench "nanomsg-haskell: 20k bytes x 40 messages, lat, inproc" $ nfIO $ nLat 20000   20 "inproc://bench" "inproc://bench"
-    , bench "zeromq3-haskell: 20k bytes x 40 messages, lat, inproc" $ nfIO $ zLat 20000   20 "inproc://bench" "inproc://bench"
+    , bench "zeromq4-haskell: 20k bytes x 40 messages, lat, inproc" $ nfIO $ zLat 20000   20 "inproc://bench" "inproc://bench"
     , bench "nanomsg-haskell: 40 bytes x 10k messages, throughput, tcp"     $ nfIO $ nThr 40 100 "tcp://*:5566" "tcp://localhost:5566"
-    , bench "zeromq3-haskell: 40 bytes x 10k messages, throughput, tcp"     $ nfIO $ zThr 40 100 "tcp://*:5566" "tcp://localhost:5566"
+    , bench "zeromq4-haskell: 40 bytes x 10k messages, throughput, tcp"     $ nfIO $ zThr 40 100 "tcp://*:5566" "tcp://localhost:5566"
     , bench "nanomsg-haskell: 40 bytes x 10k messages, throughput, inproc"  $ nfIO $ nThr 40 100 "inproc://bench" "inproc://bench"
-    , bench "zeromq3-haskell: 40 bytes x 10k messages, throughput, inproc"  $ nfIO $ zThr 40 100 "inproc://bench" "inproc://bench"
+    , bench "zeromq4-haskell: 40 bytes x 10k messages, throughput, inproc"  $ nfIO $ zThr 40 100 "inproc://bench" "inproc://bench"
     ]
 

--- a/nanomsg-haskell.cabal
+++ b/nanomsg-haskell.cabal
@@ -1,5 +1,5 @@
 name:                nanomsg-haskell
-version:             0.2.1.1
+version:             0.3
 synopsis:
   Bindings to the nanomsg library
 description:
@@ -30,7 +30,7 @@ library
   hs-source-dirs:    src
   ghc-options:       -O2 -Wall
   default-language:  Haskell2010
-  exposed-modules:   Nanomsg
+  exposed-modules:   Network.Nanomsg
   default-extensions:  ForeignFunctionInterface, DeriveDataTypeable
   includes:          nanomsg/nn.h
   extra-libraries:   nanomsg
@@ -49,9 +49,9 @@ test-suite tests
     bytestring >= 0.9.0 && < 0.11,
     nanomsg-haskell,
     QuickCheck,
-    test-framework,
-    test-framework-quickcheck2,
-    test-framework-th
+    tasty >= 0.8,
+    tasty-quickcheck,
+    tasty-th
 
 source-repository head
   type:              git
@@ -79,6 +79,6 @@ benchmark vs-zeromq-bindings
     base >= 4.5 && < 4.8,
     bytestring >= 0.9.0 && < 0.11,
     nanomsg-haskell,
-    zeromq3-haskell,
+    zeromq4-haskell,
     criterion
 

--- a/src/Network/Nanomsg.hsc
+++ b/src/Network/Nanomsg.hsc
@@ -1,6 +1,6 @@
 {-# LANGUAGE ForeignFunctionInterface, DeriveDataTypeable #-}
 -- |
--- Module:          Nanomsg
+-- Module:          Network.Nanomsg
 -- Copyright:       (c) 2013 Ivar Nymoen
 -- License:         MIT
 -- Stability:       experimental
@@ -17,7 +17,7 @@
 -- Socket type documentation is adapted or quoted verbatim from the
 -- nanomsg manual. Please refer to nanomsg.org for information on
 -- how to use the library.
-module Nanomsg
+module Network.Nanomsg
         (
         -- * Types
         -- ** Socket types

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -2,9 +2,9 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Main where
 
-import Nanomsg
-import Test.Framework.TH (defaultMainGenerator)
-import Test.Framework.Providers.QuickCheck2 (testProperty)
+import Network.Nanomsg
+import Test.Tasty.TH (defaultMainGenerator)
+import Test.Tasty.QuickCheck (testProperty)
 import Test.QuickCheck
 import Test.QuickCheck.Monadic
 import Data.ByteString (ByteString)


### PR DESCRIPTION
Hi,
I propose some changes, but these are mostly design choices, so please take them with a grain of salt:
- I think this package should be under the `Network` hierarchy of modules, or alternatively `System` (as 0MQ). Personally I think `Network` makes more sense, but any of those seem preferable to just `Nanomsg`.
- [Test-framework](https://github.com/batterseapower/test-framework) seems mostly dead. While there seems to be an [active fork](https://github.com/haskell/test-framework), [tasty](http://documentup.com/feuerbach/tasty) seems to be more actively maintained. The replacement was quite direct.
- Replaced `zeromq3-haskel` with `zeromq4-haskell`

Tests and benchmarks are passing and running, respectively.

What do you think?
