### PR TITLE
Fix bug in send

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+Unreleased
+  * Fixed bug in nonblocking send where `threadWaitWrite` was used instead of
+    `threadWaitRead`
 0.2.4
   * Bumped upper bound on binary
 0.2.3

--- a/src/Nanomsg.hsc
+++ b/src/Nanomsg.hsc
@@ -467,7 +467,7 @@ send (Socket t sid) string =
         throwErrnoIfMinus1RetryMayBlock_
             "send"
             (c_nn_send sid ptr (fromIntegral len) (#const NN_DONTWAIT))
-            (getOptionFd (Socket t sid) (#const NN_SNDFD) >>= threadWaitWrite)
+            (getOptionFd (Socket t sid) (#const NN_SNDFD) >>= threadWaitRead)
 
 -- | Blocking receive.
 recv :: Receiver a => Socket a -> IO ByteString


### PR DESCRIPTION
From the docs:

https://nanomsg.org/v1.1.5/nn_getsockopt.html

> **NN_SNDFD**
>
> Retrieves a file descriptor that is **readable when a message can be sent to the socket**. The descriptor should be used only for polling and never read from or written to. The type of the option is same as the type of file descriptor on the platform. That is, int on POSIX-complaint platforms and SOCKET on Windows. The descriptor becomes invalid and should not be used any more once the socket is closed. This socket option is not available for unidirectional recv-only socket types.

Emphasis mine, and it is not a typo, it really does mean _readable_, not _writable_. See https://github.com/nanomsg/nanomsg/issues/357
