### PR TITLE
 Support for NN_RCVMAXSIZE option

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -28,6 +28,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.12.2
+            compilerKind: ghc
+            compilerVersion: 9.12.2
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.10.1
             compilerKind: ghc
             compilerVersion: 9.10.1

--- a/changelog
+++ b/changelog
@@ -1,6 +1,7 @@
 0.2.5
   * Deprecate `NN_LINGER` option
   * Improve testsuite reliability
+  * Add support for `NN_RCVMAXSIZE` option
 
 0.2.4
   * Bumped upper bound on binary

--- a/nanomsg-haskell.cabal
+++ b/nanomsg-haskell.cabal
@@ -25,7 +25,8 @@ tested-with:
   GHC == 9.4.7,
   GHC == 9.6.5,
   GHC == 9.8.2,
-  GHC == 9.10.1
+  GHC == 9.10.1,
+  GHC == 9.12.2
 extra-source-files:
   README.md
   , CONTRIBUTORS

--- a/src/Nanomsg.hsc
+++ b/src/Nanomsg.hsc
@@ -59,6 +59,8 @@ module Nanomsg
         , setSndBuf
         , rcvBuf
         , setRcvBuf
+        , rcvMaxSize
+        , setRcvMaxSize
         , reconnectInterval
         , setReconnectInterval
         , reconnectIntervalMax
@@ -621,6 +623,24 @@ rcvBuf s =
 setRcvBuf :: Socket a -> Int -> IO ()
 setRcvBuf s val =
     setOption s (#const NN_SOL_SOCKET) (#const NN_RCVBUF) (IntOption val)
+
+-- | Maximum message size that can be received, in bytes.
+-- Negative value means that the received size is limited only by available addressable memory.
+-- The type of this option is int.
+--
+-- Default is 1024kB.
+rcvMaxSize :: Socket a -> IO Int
+rcvMaxSize s =
+    fromIntegral <$> getOption s (#const NN_SOL_SOCKET) (#const NN_RCVMAXSIZE)
+
+-- | Maximum message size that can be received, in bytes.
+-- Negative value means that the received size is limited only by available addressable memory.
+-- The type of this option is int.
+--
+-- Default is 1024kB.
+setRcvMaxSize :: Socket a -> Int -> IO ()
+setRcvMaxSize s val =
+    setOption s (#const NN_SOL_SOCKET) (#const NN_RCVMAXSIZE) (IntOption val)
 
 -- Think I'll just skip these. There's recv' for nonblocking receive, and
 -- adding a return value to send seems awkward.


### PR DESCRIPTION
As documented in https://nanomsg.org/v1.1.5/nn_setsockopt.html .

Supercedes #8.